### PR TITLE
Add model-specific remote UI and media player sound mode selection

### DIFF
--- a/intg_arcam/device.py
+++ b/intg_arcam/device.py
@@ -66,11 +66,39 @@ RC5_COMMANDS = {
     "INPUT_UHD": (0x10, 0x7D),
     "INPUT_BT": (0x10, 0x7A),
     "INPUT_GAME": (0x10, 0x61),
+    "INPUT_RADIO": (0x10, 0x5B),   # Tuner input (FM/DAB toggle)
+    # SA series inputs — reuse same RC5 codes with model-appropriate labels
+    "INPUT_PHONO": (0x10, 0x75),    # Same RC5 as INPUT_VCR (SA label)
+    "INPUT_ARC_ERC": (0x10, 0x7D),  # Same RC5 as INPUT_UHD (SA label)
+    # ST series inputs — RC5 system 21 (0x15), not system 16 (0x10)
+    "INPUT_DIG1": (0x15, 0x5E),
+    "INPUT_DIG2": (0x15, 0x62),
+    "INPUT_DIG3": (0x15, 0x1B),
+    "INPUT_DIG4": (0x15, 0x61),
+    "INPUT_USB_ST": (0x15, 0x5D),   # ST60 USB (system 21)
+    "INPUT_NET_ST": (0x15, 0x5C),   # ST60 NET (system 21)
+    # Audio mode RC5 commands — some share the same RC5 code across model series
+    # (e.g., DOLBY_PLII_MOVIE and AURO_NATIVE are both 0x67) because the receiver
+    # interprets the same IR code differently per model. We keep distinct command
+    # names so each model shows correctly labeled buttons.
     "STEREO": (0x10, 0x6B),
     "DOLBY_PLII_MOVIE": (0x10, 0x67),
     "DOLBY_PLII_MUSIC": (0x10, 0x68),
+    "DOLBY_PLII_GAME": (0x10, 0x66),
+    "DOLBY_PL": (0x10, 0x6E),
     "DTS_NEO6_CINEMA": (0x10, 0x6F),
     "DTS_NEO6_MUSIC": (0x10, 0x70),
+    "MCH_STEREO": (0x10, 0x45),
+    # MULTI_CHANNEL is not in any model's audio modes page but is kept in the
+    # RC5 table so it can be sent via automations or direct SEND_CMD calls.
+    "MULTI_CHANNEL": (0x10, 0x6A),
+    "DOLBY_SURROUND": (0x10, 0x6E),       # Same RC5 as DOLBY_PL (HDA label)
+    "DTS_NEURAL_X": (0x10, 0x71),
+    "DTS_VIRTUAL_X": (0x10, 0x73),
+    "DOLBY_VIRTUAL_HEIGHT": (0x10, 0x73),  # Same RC5 as DTS_VIRTUAL_X (HDA label)
+    "AURO_NATIVE": (0x10, 0x67),           # Same RC5 as DOLBY_PLII_MOVIE (HDA label)
+    "AURO_MATIC_3D": (0x10, 0x47),
+    "AURO_2D": (0x10, 0x68),              # Same RC5 as DOLBY_PLII_MUSIC (HDA label)
 }
 
 
@@ -182,6 +210,13 @@ class ArcamDevice(ExternalClientDevice):
     @property
     def room_eq(self) -> str | None:
         return self._room_eq
+
+    @property
+    def api_model(self) -> ApiModel | None:
+        """Detected API model series, or None if state not initialized."""
+        if self._arcam_state:
+            return self._arcam_state._api_model
+        return None
 
     # All command codes tracked for staleness (Groups 1, 2, 3)
     _ALL_TRACKED_COMMANDS: set[CommandCodes] = {
@@ -852,14 +887,16 @@ class ArcamDevice(ExternalClientDevice):
         self._state = "ON" if self._power else "OFF"
         self.push_update()
 
-    def _format_room_eq(self, index: int) -> str | None:
+    def _format_room_eq(self, index: int) -> str:
         """Format room EQ index as a display string, using name if available.
 
-        Returns None if the name is not yet known (waiting for ROOM_EQ_NAMES).
+        HDA series receivers provide named presets via ROOM_EQ_NAMES; other
+        models (e.g. 860 series) support ROOM_EQUALIZATION but not named
+        presets, so we fall back to "Preset N".
         """
         if index == 0:
             return "Off"
-        return self._room_eq_names.get(index)
+        return self._room_eq_names.get(index, f"Preset {index}")
 
     def _parse_room_eq_names(self) -> None:
         """Parse room EQ names from state data (0x34 response).

--- a/intg_arcam/media_player.py
+++ b/intg_arcam/media_player.py
@@ -36,6 +36,7 @@ class ArcamMediaPlayer(MediaPlayerEntity):
             Features.UNMUTE,
             Features.MUTE,
             Features.SELECT_SOURCE,
+            Features.SELECT_SOUND_MODE,
         ]
 
         attributes = {
@@ -44,6 +45,8 @@ class ArcamMediaPlayer(MediaPlayerEntity):
             Attributes.MUTED: False,
             Attributes.SOURCE: "",
             Attributes.SOURCE_LIST: [],
+            Attributes.SOUND_MODE: "",
+            Attributes.SOUND_MODE_LIST: [],
         }
 
         options = {
@@ -68,6 +71,8 @@ class ArcamMediaPlayer(MediaPlayerEntity):
             Attributes.MUTED: self._device.muted,
             Attributes.SOURCE: self._device.source or "",
             Attributes.SOURCE_LIST: self._device.source_list,
+            Attributes.SOUND_MODE: self._device.sound_mode or "",
+            Attributes.SOUND_MODE_LIST: self._device.sound_mode_list,
         })
 
     async def handle_command(
@@ -114,6 +119,12 @@ class ArcamMediaPlayer(MediaPlayerEntity):
             elif cmd_id == Commands.SELECT_SOURCE:
                 if params and "source" in params:
                     success = await self._device.select_source(params["source"])
+                    return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
+                return StatusCodes.BAD_REQUEST
+
+            elif cmd_id == Commands.SELECT_SOUND_MODE:
+                if params and "mode" in params:
+                    success = await self._device.set_decode_mode(params["mode"])
                     return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
                 return StatusCodes.BAD_REQUEST
 

--- a/intg_arcam/remote.py
+++ b/intg_arcam/remote.py
@@ -8,14 +8,255 @@ Arcam FMJ Remote Entity.
 import logging
 from typing import Any
 
+from arcam.fmj import ApiModel
 from ucapi import StatusCodes
 from ucapi.remote import Attributes, Commands, Features, States
+from ucapi.ui import Buttons, EntityCommand, create_btn_mapping
 from ucapi_framework import RemoteEntity
 
 from intg_arcam.config import ArcamConfig
 from intg_arcam.device import ArcamDevice, RC5_COMMANDS
 
 _LOG = logging.getLogger(__name__)
+
+# Audio mode buttons per model series.
+# Each entry is (display_label, cmd_id). The cmd_id must exist in RC5_COMMANDS.
+# "Direct" and "Mode" are common to all models and added automatically by the
+# page builder.
+_AUDIO_MODES_450 = [
+    ("Stereo", "STEREO"),
+    ("Dolby\nPLII Movie", "DOLBY_PLII_MOVIE"),
+    ("Dolby\nPLII Music", "DOLBY_PLII_MUSIC"),
+    ("Dolby\nPLII Game", "DOLBY_PLII_GAME"),
+    ("Dolby PL", "DOLBY_PL"),
+    ("DTS Neo:6\nCinema", "DTS_NEO6_CINEMA"),
+    ("DTS Neo:6\nMusic", "DTS_NEO6_MUSIC"),
+    ("MCH Stereo", "MCH_STEREO"),
+]
+
+_AUDIO_MODES_860 = [
+    ("Stereo", "STEREO"),
+    ("Dolby PL", "DOLBY_PL"),
+    ("DTS\nNeural:X", "DTS_NEURAL_X"),
+    ("DTS\nVirtual:X", "DTS_VIRTUAL_X"),
+    ("DTS Neo:6\nCinema", "DTS_NEO6_CINEMA"),
+    ("DTS Neo:6\nMusic", "DTS_NEO6_MUSIC"),
+    ("MCH Stereo", "MCH_STEREO"),
+]
+
+_AUDIO_MODES_HDA = [
+    ("Stereo", "STEREO"),
+    ("Dolby\nSurround", "DOLBY_SURROUND"),
+    ("DTS\nNeural:X", "DTS_NEURAL_X"),
+    ("DTS Neo:6\nCinema", "DTS_NEO6_CINEMA"),
+    ("DTS Neo:6\nMusic", "DTS_NEO6_MUSIC"),
+    ("MCH Stereo", "MCH_STEREO"),
+    ("Dolby\nVirt. Height", "DOLBY_VIRTUAL_HEIGHT"),
+    ("Auro\nNative", "AURO_NATIVE"),
+    ("Auro-Matic\n3D", "AURO_MATIC_3D"),
+    ("Auro-2D", "AURO_2D"),
+]
+
+# SA/PA/ST series have no audio decode modes (stereo amps, power amps, streamers).
+_AUDIO_MODES_SA: list[tuple[str, str]] = []
+_AUDIO_MODES_PA: list[tuple[str, str]] = []
+_AUDIO_MODES_ST: list[tuple[str, str]] = []
+
+_AUDIO_MODES_BY_MODEL = {
+    ApiModel.API450_SERIES: _AUDIO_MODES_450,
+    ApiModel.API860_SERIES: _AUDIO_MODES_860,
+    ApiModel.APIHDA_SERIES: _AUDIO_MODES_HDA,
+    ApiModel.APISA_SERIES: _AUDIO_MODES_SA,
+    ApiModel.APIPA_SERIES: _AUDIO_MODES_PA,
+    ApiModel.APIST_SERIES: _AUDIO_MODES_ST,
+}
+
+# Input source buttons per model series.
+# Each entry is (display_label, cmd_id). Ordered to match the physical remote's
+# 4×3 grid layout, read left-to-right, top-to-bottom.
+_INPUT_SOURCES_450 = [
+    ("TUN", "INPUT_RADIO"), ("AUX", "INPUT_AUX"), ("NET", "INPUT_NET"), ("USB", "INPUT_USB"),
+    ("BD", "INPUT_BD"),     ("AV", "INPUT_AV"),   ("VCR", "INPUT_VCR"), ("GAME", "INPUT_GAME"),
+    ("STB", "INPUT_STB"),   ("SAT", "INPUT_SAT"), ("PVR", "INPUT_PVR"), ("CD", "INPUT_CD"),
+]
+
+_INPUT_SOURCES_860 = [
+    ("Radio", "INPUT_RADIO"), ("AUX", "INPUT_AUX"), ("NET", "INPUT_NET"), ("USB", "INPUT_USB"),
+    ("AV", "INPUT_AV"),      ("SAT", "INPUT_SAT"), ("PVR", "INPUT_PVR"), ("GAME", "INPUT_GAME"),
+    ("BD", "INPUT_BD"),      ("CD", "INPUT_CD"),   ("STB", "INPUT_STB"), ("VCR", "INPUT_VCR"),
+]
+
+_INPUT_SOURCES_HDA = [
+    ("Radio", "INPUT_RADIO"), ("AUX", "INPUT_AUX"), ("NET", "INPUT_NET"), ("BT", "INPUT_BT"),
+    ("AV", "INPUT_AV"),      ("SAT", "INPUT_SAT"), ("PVR", "INPUT_PVR"), ("GAME", "INPUT_GAME"),
+    ("BD", "INPUT_BD"),      ("CD", "INPUT_CD"),   ("STB", "INPUT_STB"), ("UHD", "INPUT_UHD"),
+]
+
+_INPUT_SOURCES_SA = [
+    ("Phono", "INPUT_PHONO"), ("CD", "INPUT_CD"),  ("BD", "INPUT_BD"),     ("SAT", "INPUT_SAT"),
+    ("PVR", "INPUT_PVR"),     ("AV", "INPUT_AV"),  ("AUX", "INPUT_AUX"),   ("STB", "INPUT_STB"),
+    ("NET", "INPUT_NET"),     ("USB", "INPUT_USB"), ("GAME", "INPUT_GAME"), ("ARC", "INPUT_ARC_ERC"),
+]
+
+_INPUT_SOURCES_ST = [
+    ("DIG 1", "INPUT_DIG1"), ("DIG 2", "INPUT_DIG2"),
+    ("DIG 3", "INPUT_DIG3"), ("DIG 4", "INPUT_DIG4"),
+    ("USB", "INPUT_USB_ST"), ("NET", "INPUT_NET_ST"),
+]
+
+# PA series: pure power amplifiers, no input selection.
+_INPUT_SOURCES_PA: list[tuple[str, str]] = []
+
+_INPUT_SOURCES_BY_MODEL = {
+    ApiModel.API450_SERIES: _INPUT_SOURCES_450,
+    ApiModel.API860_SERIES: _INPUT_SOURCES_860,
+    ApiModel.APIHDA_SERIES: _INPUT_SOURCES_HDA,
+    ApiModel.APISA_SERIES: _INPUT_SOURCES_SA,
+    ApiModel.APIPA_SERIES: _INPUT_SOURCES_PA,
+    ApiModel.APIST_SERIES: _INPUT_SOURCES_ST,
+}
+
+# Model capability sets — used to conditionally build remote pages.
+_MODELS_WITH_TUNER = {ApiModel.API450_SERIES, ApiModel.API860_SERIES, ApiModel.APIHDA_SERIES}
+_MODELS_WITH_OSD = {
+    ApiModel.API450_SERIES, ApiModel.API860_SERIES, ApiModel.APIHDA_SERIES,
+    ApiModel.APISA_SERIES, ApiModel.APIST_SERIES,
+}
+
+# Simple commands split by capability for conditional registration.
+_NAVIGATION_COMMANDS = [
+    "CURSOR_UP", "CURSOR_DOWN", "CURSOR_LEFT", "CURSOR_RIGHT",
+    "OK", "MENU", "BACK", "INFO", "DISPLAY",
+]
+
+_TUNER_COMMANDS = [
+    "TUNER_BAND", "PRESET_UP", "PRESET_DOWN", "INPUT_FM", "INPUT_DAB",
+]
+
+# Always registered — harmless for models that don't use them, and useful in automations.
+_ALWAYS_COMMANDS = ["MODE", "DIRECT"]
+
+
+def _build_audio_modes_page(modes: list[tuple[str, str]]) -> dict | None:
+    """Build the Audio Modes page from a list of (label, cmd_id) tuples.
+
+    Returns None if modes is empty (e.g. SA/PA/ST series with no decode modes).
+
+    Lays out 2-wide buttons in a 4-column grid. The first row pairs the first
+    mode (typically Stereo) with Direct. Remaining modes fill subsequent rows
+    two at a time. When the remaining count is odd, Mode sits alongside the
+    last mode; otherwise Mode gets a full-width row at the bottom.
+    """
+    if not modes:
+        return None
+
+    items = []
+    row = 0
+
+    # First row: first mode + Direct
+    items.append({
+        "type": "text",
+        "text": modes[0][0],
+        "command": {"cmd_id": modes[0][1]},
+        "location": {"x": 0, "y": row},
+        "size": {"width": 2, "height": 1},
+    })
+    items.append({
+        "type": "text",
+        "text": "Direct",
+        "command": {"cmd_id": "DIRECT"},
+        "location": {"x": 2, "y": row},
+        "size": {"width": 2, "height": 1},
+    })
+    row += 1
+
+    # Remaining modes: 2 per row
+    remaining = modes[1:]
+    odd_remaining = len(remaining) % 2 == 1
+    paired = remaining if not odd_remaining else remaining[:-1]
+
+    for i in range(0, len(paired), 2):
+        items.append({
+            "type": "text",
+            "text": paired[i][0],
+            "command": {"cmd_id": paired[i][1]},
+            "location": {"x": 0, "y": row},
+            "size": {"width": 2, "height": 1},
+        })
+        items.append({
+            "type": "text",
+            "text": paired[i + 1][0],
+            "command": {"cmd_id": paired[i + 1][1]},
+            "location": {"x": 2, "y": row},
+            "size": {"width": 2, "height": 1},
+        })
+        row += 1
+
+    if odd_remaining:
+        # Last unpaired mode on the left, Mode button on the right
+        items.append({
+            "type": "text",
+            "text": remaining[-1][0],
+            "command": {"cmd_id": remaining[-1][1]},
+            "location": {"x": 0, "y": row},
+            "size": {"width": 2, "height": 1},
+        })
+        items.append({
+            "type": "text",
+            "text": "Mode",
+            "command": {"cmd_id": "MODE"},
+            "location": {"x": 2, "y": row},
+            "size": {"width": 2, "height": 1},
+        })
+        row += 1
+    else:
+        # Mode button — full width on its own row
+        items.append({
+            "type": "text",
+            "text": "Mode",
+            "command": {"cmd_id": "MODE"},
+            "location": {"x": 0, "y": row},
+            "size": {"width": 4, "height": 1},
+        })
+        row += 1
+
+    return {
+        "page_id": "audio_modes",
+        "name": "Audio Modes",
+        # Height is fixed at 6 — the UC Remote stretches grid cells to fill the
+        # display, so a tight height makes buttons uncomfortably tall.
+        "grid": {"width": 4, "height": 6},
+        "items": items,
+    }
+
+
+def _build_sources_page(sources: list[tuple[str, str]]) -> dict | None:
+    """Build the Sources page from a list of (label, cmd_id) tuples.
+
+    Returns None if sources is empty (e.g. PA series with no input selection).
+
+    Lays out 1×1 buttons in a 4-column grid, filling left-to-right,
+    top-to-bottom to match the physical remote's button arrangement.
+    """
+    if not sources:
+        return None
+
+    items = []
+    for i, (label, cmd_id) in enumerate(sources):
+        items.append({
+            "type": "text",
+            "text": label,
+            "command": {"cmd_id": cmd_id},
+            "location": {"x": i % 4, "y": i // 4},
+        })
+
+    return {
+        "page_id": "sources",
+        "name": "Sources",
+        # Height is fixed at 6 — see audio_modes page comment.
+        "grid": {"width": 4, "height": 6},
+        "items": items,
+    }
 
 
 class ArcamRemote(RemoteEntity):
@@ -33,328 +274,174 @@ class ArcamRemote(RemoteEntity):
             Attributes.STATE: States.UNKNOWN,
         }
 
-        simple_commands = [
-            "CURSOR_UP",
-            "CURSOR_DOWN",
-            "CURSOR_LEFT",
-            "CURSOR_RIGHT",
-            "OK",
-            "MENU",
-            "BACK",
-            "INFO",
-            "DISPLAY",
-            "MODE",
-            "DIRECT",
-            "TUNER_BAND",
-            "PRESET_UP",
-            "PRESET_DOWN",
-            "INPUT_CD",
-            "INPUT_BD",
-            "INPUT_AV",
-            "INPUT_SAT",
-            "INPUT_PVR",
-            "INPUT_VCR",
-            "INPUT_AUX",
-            "INPUT_FM",
-            "INPUT_DAB",
-            "INPUT_NET",
-            "INPUT_USB",
-            "INPUT_STB",
-            "INPUT_UHD",
-            "INPUT_BT",
-            "INPUT_GAME",
-            "STEREO",
-            "DOLBY_PLII_MOVIE",
-            "DOLBY_PLII_MUSIC",
-            "DTS_NEO6_CINEMA",
-            "DTS_NEO6_MUSIC",
-        ]
+        model = device.api_model or ApiModel.API450_SERIES
+        has_osd = model in _MODELS_WITH_OSD
+        has_tuner = model in _MODELS_WITH_TUNER
 
-        user_interface = {
-            "pages": [
-                {
-                    "page_id": "navigation",
-                    "name": "Navigation",
-                    "grid": {"width": 4, "height": 6},
-                    "items": [
-                        {
-                            "type": "text",
-                            "text": "Menu",
-                            "command": {"cmd_id": "MENU"},
-                            "location": {"x": 0, "y": 0},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Info",
-                            "command": {"cmd_id": "INFO"},
-                            "location": {"x": 2, "y": 0},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "icon",
-                            "icon": "uc:up-arrow",
-                            "command": {"cmd_id": "CURSOR_UP"},
-                            "location": {"x": 1, "y": 1},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "icon",
-                            "icon": "uc:left-arrow",
-                            "command": {"cmd_id": "CURSOR_LEFT"},
-                            "location": {"x": 0, "y": 2},
-                        },
-                        {
-                            "type": "text",
-                            "text": "OK",
-                            "command": {"cmd_id": "OK"},
-                            "location": {"x": 1, "y": 2},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "icon",
-                            "icon": "uc:right-arrow",
-                            "command": {"cmd_id": "CURSOR_RIGHT"},
-                            "location": {"x": 3, "y": 2},
-                        },
-                        {
-                            "type": "icon",
-                            "icon": "uc:down-arrow",
-                            "command": {"cmd_id": "CURSOR_DOWN"},
-                            "location": {"x": 1, "y": 3},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Back",
-                            "command": {"cmd_id": "BACK"},
-                            "location": {"x": 0, "y": 4},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Display",
-                            "command": {"cmd_id": "DISPLAY"},
-                            "location": {"x": 2, "y": 4},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Mode",
-                            "command": {"cmd_id": "MODE"},
-                            "location": {"x": 0, "y": 5},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Direct",
-                            "command": {"cmd_id": "DIRECT"},
-                            "location": {"x": 2, "y": 5},
-                            "size": {"width": 2, "height": 1},
-                        },
-                    ],
-                },
-                {
-                    "page_id": "audio_modes",
-                    "name": "Audio Modes",
-                    "grid": {"width": 4, "height": 6},
-                    "items": [
-                        {
-                            "type": "text",
-                            "text": "Stereo",
-                            "command": {"cmd_id": "STEREO"},
-                            "location": {"x": 0, "y": 0},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Direct",
-                            "command": {"cmd_id": "DIRECT"},
-                            "location": {"x": 2, "y": 0},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Dolby\nPLII Movie",
-                            "command": {"cmd_id": "DOLBY_PLII_MOVIE"},
-                            "location": {"x": 0, "y": 1},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Dolby\nPLII Music",
-                            "command": {"cmd_id": "DOLBY_PLII_MUSIC"},
-                            "location": {"x": 2, "y": 1},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "DTS Neo:6\nCinema",
-                            "command": {"cmd_id": "DTS_NEO6_CINEMA"},
-                            "location": {"x": 0, "y": 2},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "DTS Neo:6\nMusic",
-                            "command": {"cmd_id": "DTS_NEO6_MUSIC"},
-                            "location": {"x": 2, "y": 2},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Mode",
-                            "command": {"cmd_id": "MODE"},
-                            "location": {"x": 0, "y": 3},
-                            "size": {"width": 4, "height": 1},
-                        },
-                    ],
-                },
-                {
-                    "page_id": "sources",
-                    "name": "Sources",
-                    "grid": {"width": 4, "height": 6},
-                    "items": [
-                        {
-                            "type": "text",
-                            "text": "BD",
-                            "command": {"cmd_id": "INPUT_BD"},
-                            "location": {"x": 0, "y": 0},
-                        },
-                        {
-                            "type": "text",
-                            "text": "SAT",
-                            "command": {"cmd_id": "INPUT_SAT"},
-                            "location": {"x": 1, "y": 0},
-                        },
-                        {
-                            "type": "text",
-                            "text": "AV",
-                            "command": {"cmd_id": "INPUT_AV"},
-                            "location": {"x": 2, "y": 0},
-                        },
-                        {
-                            "type": "text",
-                            "text": "GAME",
-                            "command": {"cmd_id": "INPUT_GAME"},
-                            "location": {"x": 3, "y": 0},
-                        },
-                        {
-                            "type": "text",
-                            "text": "STB",
-                            "command": {"cmd_id": "INPUT_STB"},
-                            "location": {"x": 0, "y": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "PVR",
-                            "command": {"cmd_id": "INPUT_PVR"},
-                            "location": {"x": 1, "y": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "VCR",
-                            "command": {"cmd_id": "INPUT_VCR"},
-                            "location": {"x": 2, "y": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "AUX",
-                            "command": {"cmd_id": "INPUT_AUX"},
-                            "location": {"x": 3, "y": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "CD",
-                            "command": {"cmd_id": "INPUT_CD"},
-                            "location": {"x": 0, "y": 2},
-                        },
-                        {
-                            "type": "text",
-                            "text": "NET",
-                            "command": {"cmd_id": "INPUT_NET"},
-                            "location": {"x": 1, "y": 2},
-                        },
-                        {
-                            "type": "text",
-                            "text": "USB",
-                            "command": {"cmd_id": "INPUT_USB"},
-                            "location": {"x": 2, "y": 2},
-                        },
-                        {
-                            "type": "text",
-                            "text": "UHD",
-                            "command": {"cmd_id": "INPUT_UHD"},
-                            "location": {"x": 3, "y": 2},
-                        },
-                        {
-                            "type": "text",
-                            "text": "FM",
-                            "command": {"cmd_id": "INPUT_FM"},
-                            "location": {"x": 0, "y": 3},
-                        },
-                        {
-                            "type": "text",
-                            "text": "DAB",
-                            "command": {"cmd_id": "INPUT_DAB"},
-                            "location": {"x": 1, "y": 3},
-                        },
-                        {
-                            "type": "text",
-                            "text": "BT",
-                            "command": {"cmd_id": "INPUT_BT"},
-                            "location": {"x": 2, "y": 3},
-                        },
-                    ],
-                },
-                {
-                    "page_id": "tuner",
-                    "name": "Tuner",
-                    "grid": {"width": 4, "height": 6},
-                    "items": [
-                        {
-                            "type": "text",
-                            "text": "FM",
-                            "command": {"cmd_id": "INPUT_FM"},
-                            "location": {"x": 0, "y": 0},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "DAB",
-                            "command": {"cmd_id": "INPUT_DAB"},
-                            "location": {"x": 2, "y": 0},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Band",
-                            "command": {"cmd_id": "TUNER_BAND"},
-                            "location": {"x": 0, "y": 1},
-                            "size": {"width": 4, "height": 1},
-                        },
-                        {
-                            "type": "text",
-                            "text": "Preset",
-                            "location": {"x": 0, "y": 2},
-                            "size": {"width": 2, "height": 1},
-                        },
-                        {
-                            "type": "icon",
-                            "icon": "uc:up-arrow",
-                            "command": {"cmd_id": "PRESET_UP"},
-                            "location": {"x": 2, "y": 2},
-                        },
-                        {
-                            "type": "icon",
-                            "icon": "uc:down-arrow",
-                            "command": {"cmd_id": "PRESET_DOWN"},
-                            "location": {"x": 3, "y": 2},
-                        },
-                    ],
-                },
-            ]
-        }
+        # Select audio modes and input sources for the detected model
+        audio_modes = _AUDIO_MODES_BY_MODEL.get(model, _AUDIO_MODES_450)
+        input_sources = _INPUT_SOURCES_BY_MODEL.get(model, _INPUT_SOURCES_450)
+
+        # Build simple_commands from capability-appropriate command sets
+        simple_commands = list(_ALWAYS_COMMANDS)
+        if has_osd:
+            simple_commands.extend(_NAVIGATION_COMMANDS)
+        if has_tuner:
+            simple_commands.extend(_TUNER_COMMANDS)
+        for _, cmd_id in audio_modes:
+            if cmd_id not in simple_commands:
+                simple_commands.append(cmd_id)
+        for _, cmd_id in input_sources:
+            if cmd_id not in simple_commands:
+                simple_commands.append(cmd_id)
+
+        # Build pages conditionally based on model capabilities
+        pages = []
+
+        if has_osd:
+            pages.append({
+                "page_id": "navigation",
+                "name": "Navigation",
+                "grid": {"width": 4, "height": 6},
+                "items": [
+                    {
+                        "type": "text",
+                        "text": "Menu",
+                        "command": {"cmd_id": "MENU"},
+                        "location": {"x": 0, "y": 0},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Info",
+                        "command": {"cmd_id": "INFO"},
+                        "location": {"x": 2, "y": 0},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "icon",
+                        "icon": "uc:up-arrow",
+                        "command": {"cmd_id": "CURSOR_UP"},
+                        "location": {"x": 1, "y": 1},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "icon",
+                        "icon": "uc:left-arrow",
+                        "command": {"cmd_id": "CURSOR_LEFT"},
+                        "location": {"x": 0, "y": 2},
+                    },
+                    {
+                        "type": "text",
+                        "text": "OK",
+                        "command": {"cmd_id": "OK"},
+                        "location": {"x": 1, "y": 2},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "icon",
+                        "icon": "uc:right-arrow",
+                        "command": {"cmd_id": "CURSOR_RIGHT"},
+                        "location": {"x": 3, "y": 2},
+                    },
+                    {
+                        "type": "icon",
+                        "icon": "uc:down-arrow",
+                        "command": {"cmd_id": "CURSOR_DOWN"},
+                        "location": {"x": 1, "y": 3},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Back",
+                        "command": {"cmd_id": "BACK"},
+                        "location": {"x": 0, "y": 4},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Display",
+                        "command": {"cmd_id": "DISPLAY"},
+                        "location": {"x": 2, "y": 4},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Mode",
+                        "command": {"cmd_id": "MODE"},
+                        "location": {"x": 0, "y": 5},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Direct",
+                        "command": {"cmd_id": "DIRECT"},
+                        "location": {"x": 2, "y": 5},
+                        "size": {"width": 2, "height": 1},
+                    },
+                ],
+            })
+
+        audio_modes_page = _build_audio_modes_page(audio_modes)
+        if audio_modes_page is not None:
+            pages.append(audio_modes_page)
+
+        sources_page = _build_sources_page(input_sources)
+        if sources_page is not None:
+            pages.append(sources_page)
+
+        if has_tuner:
+            pages.append({
+                "page_id": "tuner",
+                "name": "Tuner",
+                # Height is fixed at 6 — see audio_modes page comment.
+                "grid": {"width": 4, "height": 6},
+                "items": [
+                    {
+                        "type": "text",
+                        "text": "FM",
+                        "command": {"cmd_id": "INPUT_FM"},
+                        "location": {"x": 0, "y": 0},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "DAB",
+                        "command": {"cmd_id": "INPUT_DAB"},
+                        "location": {"x": 2, "y": 0},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Band",
+                        "command": {"cmd_id": "TUNER_BAND"},
+                        "location": {"x": 0, "y": 1},
+                        "size": {"width": 4, "height": 1},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Preset",
+                        "location": {"x": 0, "y": 2},
+                        "size": {"width": 2, "height": 1},
+                    },
+                    {
+                        "type": "icon",
+                        "icon": "uc:up-arrow",
+                        "command": {"cmd_id": "PRESET_UP"},
+                        "location": {"x": 2, "y": 2},
+                    },
+                    {
+                        "type": "icon",
+                        "icon": "uc:down-arrow",
+                        "command": {"cmd_id": "PRESET_DOWN"},
+                        "location": {"x": 3, "y": 2},
+                    },
+                ],
+            })
+
+        button_mapping = [
+            create_btn_mapping(Buttons.DPAD_MIDDLE, short=EntityCommand(cmd_id="OK")),
+        ] if has_osd else []
 
         super().__init__(
             entity_id,
@@ -362,12 +449,14 @@ class ArcamRemote(RemoteEntity):
             features,
             attributes,
             simple_commands=simple_commands,
-            ui_pages=user_interface["pages"],
+            button_mapping=button_mapping,
+            ui_pages=pages,
             cmd_handler=self.handle_command,
         )
         self.subscribe_to_device(device)
 
-        _LOG.info("[%s] Remote entity initialized with %d commands", entity_id, len(simple_commands))
+        _LOG.info("[%s] Remote entity initialized with %d commands, %d pages (model: %s)",
+                  entity_id, len(simple_commands), len(pages), model)
 
     async def sync_state(self):
         self.update({

--- a/intg_arcam/select.py
+++ b/intg_arcam/select.py
@@ -19,7 +19,12 @@ _LOG = logging.getLogger(__name__)
 
 
 class ArcamSoundModeSelect(SelectEntity):
-    """Select entity for sound/decode mode selection."""
+    """Select entity for sound/decode mode selection.
+
+    Note: Sound mode selection is also available via the media player entity's
+    SELECT_SOUND_MODE feature. This select entity may be deprecated in a future
+    release if it proves redundant.
+    """
 
     def __init__(self, device_config: ArcamConfig, device: ArcamDevice):
         self._device = device
@@ -51,6 +56,21 @@ class ArcamSoundModeSelect(SelectEntity):
             Attributes.OPTIONS: self._device.sound_mode_list,
         })
 
+    def _cycle_option(self, offset: int) -> str | None:
+        """Return the option at +/- offset from the current, wrapping around.
+
+        Returns None if the options list is empty. If the current mode is
+        unknown or not in the list, starts from the first option.
+        """
+        modes = self._device.sound_mode_list
+        if not modes:
+            return None
+        current = self._device.sound_mode
+        if not current or current not in modes:
+            return modes[0]
+        idx = (modes.index(current) + offset) % len(modes)
+        return modes[idx]
+
     async def handle_command(
         self, entity: SelectEntity, cmd_id: str, params: dict[str, Any] | None
     ) -> StatusCodes:
@@ -60,6 +80,16 @@ class ArcamSoundModeSelect(SelectEntity):
             if cmd_id == Commands.SELECT_OPTION and params and "option" in params:
                 mode_name = params["option"]
                 success = await self._device.set_decode_mode(mode_name)
+                return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
+
+            if cmd_id in (Commands.SELECT_NEXT, Commands.SELECT_PREVIOUS):
+                offset = 1 if cmd_id == Commands.SELECT_NEXT else -1
+                target = self._cycle_option(offset)
+                if target is None:
+                    _LOG.warning("[%s] Cannot cycle: current=%r, modes=%r",
+                                self.id, self._device.sound_mode, self._device.sound_mode_list)
+                    return StatusCodes.BAD_REQUEST
+                success = await self._device.set_decode_mode(target)
                 return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
 
             return StatusCodes.NOT_IMPLEMENTED


### PR DESCRIPTION
## Summary

- Remote entity UI pages (audio modes, sources, navigation, tuner) are now built dynamically based on the detected model series (450, 860, HDA, SA, PA, ST) instead of a hardcoded one-size-fits-all layout
- Media player entity now supports sound mode selection via `SELECT_SOUND_MODE`
- Sound mode select entity now handles `SELECT_NEXT` / `SELECT_PREVIOUS` commands with wrap-around cycling

## Changes

### Remote entity (remote.py)
- Audio modes page shows model-appropriate modes (e.g., Dolby PLII for 450, Dolby Surround/Auro for HDA, DTS Virtual:X for 860)
- Sources page shows model-appropriate inputs (e.g., no UHD/BT on 450, Phono/ARC on SA, DIG1-4 on ST)
- Navigation and tuner pages are conditionally included based on model capabilities
- DPAD_MIDDLE button mapped to OK for models with OSD
- Page grid heights fixed at 6 to prevent button stretching on the Remote display

### Media player (media_player.py)
- Added `SELECT_SOUND_MODE` feature with `sound_mode` and `sound_mode_list` attributes
- Sound mode can be changed directly from the media player entity UI

### Device (device.py)
- Added RC5 commands for SA series inputs (Phono, ARC/ERC), ST series inputs (DIG1-4, USB, NET on system 21), and expanded audio modes (Dolby PLII Game, Dolby PL, MCH Stereo, Dolby Surround, DTS Neural:X, DTS Virtual:X, Auro Native/Matic/2D, etc.)
- Exposed `api_model` property for use by other entities
- Room EQ display now falls back to "Preset N" for models that support ROOM_EQUALIZATION but not named presets (e.g., 860 series)

### Select entity (select.py)
- Added `SELECT_NEXT` / `SELECT_PREVIOUS` command handling with wrap-around
- Gracefully handles unknown current mode by starting from the first available option

## Upgrade notes

- **Remote entity pages will change on upgrade.** Users who previously had the generic remote layout will see model-specific pages after upgrading. The navigation page is unchanged for AVR models, but audio modes and sources will show only the buttons relevant to their receiver. Users may need to re-add the remote entity to their activities if the Remote caches the old page layout.
- **New media player attribute.** The media player now reports `sound_mode` and `sound_mode_list`. These are empty until audio is playing and the receiver reports its active decode mode. This is expected behavior, not a bug.
- **No breaking changes to existing commands.** All previously available RC5 commands still work. New commands were added but none were removed.